### PR TITLE
Upated parameterised constuctor of MatchArm to take location data

### DIFF
--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -4225,7 +4225,6 @@ private:
   // inlined from MatchArmGuard
   std::unique_ptr<Expr> guard_expr;
 
-  // TODO: should this store location data?
   Location locus;
 
 public:
@@ -4234,9 +4233,8 @@ public:
 
   // Constructor for match arm with a guard expression
   MatchArm (std::vector<std::unique_ptr<Pattern> > match_arm_patterns,
-	    std::unique_ptr<Expr> guard_expr = nullptr,
-	    std::vector<Attribute> outer_attrs = std::vector<Attribute> (),
-	    Location locus = Location ())
+	    Location locus, std::unique_ptr<Expr> guard_expr = nullptr,
+	    std::vector<Attribute> outer_attrs = std::vector<Attribute> ())
     : outer_attrs (std::move (outer_attrs)),
       match_arm_patterns (std::move (match_arm_patterns)),
       guard_expr (std::move (guard_expr)), locus (locus)
@@ -4285,7 +4283,8 @@ public:
   // Creates a match arm in an error state.
   static MatchArm create_error ()
   {
-    return MatchArm (std::vector<std::unique_ptr<Pattern> > ());
+    Location locus = Location ();
+    return MatchArm (std::vector<std::unique_ptr<Pattern> > (), locus);
   }
 
   std::string as_string () const;

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -693,7 +693,7 @@ public:
 	    match_arm_patterns.push_back (std::unique_ptr<HIR::Pattern> (ptrn));
 	  }
 
-	HIR::MatchArm arm (std::move (match_arm_patterns),
+	HIR::MatchArm arm (std::move (match_arm_patterns), expr.get_locus (),
 			   std::unique_ptr<HIR::Expr> (kase_guard_expr),
 			   match_case.get_arm ().get_outer_attrs ());
 

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -3721,9 +3721,8 @@ public:
 
   // Constructor for match arm with a guard expression
   MatchArm (std::vector<std::unique_ptr<Pattern> > match_arm_patterns,
-	    std::unique_ptr<Expr> guard_expr = nullptr,
-	    AST::AttrVec outer_attrs = AST::AttrVec (),
-	    Location locus = Location ())
+	    Location locus, std::unique_ptr<Expr> guard_expr = nullptr,
+	    AST::AttrVec outer_attrs = AST::AttrVec ())
     : outer_attrs (std::move (outer_attrs)),
       match_arm_patterns (std::move (match_arm_patterns)),
       guard_expr (std::move (guard_expr)), locus (locus)
@@ -3770,7 +3769,8 @@ public:
   // Creates a match arm in an error state.
   static MatchArm create_error ()
   {
-    return MatchArm (std::vector<std::unique_ptr<Pattern> > ());
+    Location locus = Location ();
+    return MatchArm (std::vector<std::unique_ptr<Pattern> > (), locus);
   }
 
   std::string as_string () const;

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -8560,8 +8560,9 @@ Parser<ManagedTokenSource>::parse_match_arm ()
   // DEBUG
   rust_debug ("successfully parsed match arm");
 
-  return AST::MatchArm (std::move (match_arm_patterns), std::move (guard_expr),
-			std::move (outer_attrs));
+  return AST::MatchArm (std::move (match_arm_patterns),
+			lexer.peek_token ()->get_locus (),
+			std::move (guard_expr), std::move (outer_attrs));
 }
 
 /* Parses the patterns used in a match arm. End token id is the id of the token


### PR DESCRIPTION
Addresses issue #863 
1)comment removed form rust-expr.h
2)changed partameterized constructor and static function in
  rust-hir-expr.h
3)changed line 697 to pass expr.get_locus() in rust-ast-lower
4)changed parameterised constructor in rust-expr.h
5)changed line 8563 in rust-parse-impl.h to pass location data.

Signed-off-by : M V V S Manoj Kumar <mvvsmanojkumar@gmail.com>
